### PR TITLE
add a .gitkeep file to the images/sprites directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -96,6 +96,11 @@ module.exports = yeoman.generators.Base.extend({
         this.templatePath('emptyfile'),
         this.destinationPath('app/css/sprites/index' + this.cssExtension)
       );
+
+      this.fs.copy(
+        this.templatePath('emptyfile'),
+        this.destinationPath('app/images/sprites/.gitkeep')
+      );
     },
 
     packageJSON: function () {


### PR DESCRIPTION
When generating a new project, this directory will be empty by default,
causing git to ignore it. This empty file will ensure git is aware
of this directory.

The gulp file is constructed in such a way that an error will occur if this
directory is not present, so when I gave my friend a copy of the git
repository of my new project, they were not able to run the project
until adding this directory manually.
